### PR TITLE
fix: avoid overflowing on isize as usize

### DIFF
--- a/runtime/Rust/src/common_token_stream.rs
+++ b/runtime/Rust/src/common_token_stream.rs
@@ -166,11 +166,11 @@ impl<'input, T: TokenSource<'input>> CommonTokenStream<'input, T> {
 
         let mut token = self.base.tokens[i as usize].borrow();
         while token.get_channel() != channel {
+            i += direction;
             if token.get_token_type() == EOF || i < 0 {
                 return i;
             }
 
-            i += direction;
             self.sync(i);
             token = self.base.tokens[i as usize].borrow();
         }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->