### PR TITLE
Fix: The generated parser code from pure parser grammar can't build

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Rust/Rust.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Rust/Rust.stg
@@ -551,7 +551,7 @@ antlr4rust::tid!{<currentRule.ctxType>All\<'a>}
 
 impl\<'input> antlr4rust::parser_rule_context::DerefSeal for <currentRule.ctxType>All\<'input>{}
 
-impl\<'input> <parser.grammarName>ParserContext\<'input> for <currentRule.ctxType>All\<'input>{}
+impl\<'input> <parser.name>Context\<'input> for <currentRule.ctxType>All\<'input>{}
 
 impl\<'input> Deref for <currentRule.ctxType>All\<'input>{
 	type Target = dyn <currentRule.ctxType>Attrs\<'input> + 'input;


### PR DESCRIPTION
Fix issue [#20 ](https://github.com/antlr4rust/antlr4/issues/20)
