### PR TITLE
fix: No need for these parens

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Rust/Rust.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Rust/Rust.stg
@@ -851,7 +851,7 @@ testShiftInRange(shiftAmount) ::= <<
 
 // produces smaller bytecode only when bits.tokens contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
-(<testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((1usize \<\< <offsetShift(s.varName, bits.shift)>) & <bits.calculated>) != 0)
+<testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((1usize \<\< <offsetShift(s.varName, bits.shift)>) & <bits.calculated>) != 0
 %>
 
 isZero ::= [


### PR DESCRIPTION
Fix for #22 

Pretty sure this is fine and fixes the compiler warnings. @rrevenantt if you think there is an issue, can you come up with a test case for it?