### PR TITLE
feat: Include rule name in parse error messages

### DIFF
--- a/runtime/Rust/src/error_strategy.rs
+++ b/runtime/Rust/src/error_strategy.rs
@@ -199,7 +199,12 @@ impl<'input, Ctx: ParserNodeType<'input>> DefaultErrorStrategy<'input, Ctx> {
             )
         };
 
-        format!("no viable alternative at input '{}'", input)
+        let rule_name =
+            recognizer.get_rule_names()[recognizer.get_parser_rule_context().get_rule_index()];
+        format!(
+            "no viable alternative at input '{}' in rule '{}'",
+            input, rule_name
+        )
     }
 
     fn report_input_mismatch<T: Parser<'input, Node = Ctx, TF = Ctx::TF>>(
@@ -207,12 +212,15 @@ impl<'input, Ctx: ParserNodeType<'input>> DefaultErrorStrategy<'input, Ctx> {
         recognizer: &T,
         e: &InputMisMatchError,
     ) -> String {
+        let rule_name =
+            recognizer.get_rule_names()[recognizer.get_parser_rule_context().get_rule_index()];
         format!(
-            "mismatched input {} expecting {}",
+            "mismatched input {} expecting {} in rule '{}'",
             self.get_token_error_display(&e.base.offending_token),
             e.base
                 .get_expected_tokens(recognizer)
-                .to_token_string(recognizer.get_vocabulary())
+                .to_token_string(recognizer.get_vocabulary()),
+            rule_name
         )
     }
 

--- a/runtime/Rust/tests/general_tests.rs
+++ b/runtime/Rust/tests/general_tests.rs
@@ -16,6 +16,7 @@ mod gen {
     use antlr4rust::errors::ANTLRError;
     use antlr4rust::int_stream::IntStream;
     use antlr4rust::lexer::Lexer;
+    use antlr4rust::parser::Parser as _;
 
     use antlr4rust::token::{Token, TOKEN_EOF};
     use antlr4rust::token_factory::{ArenaCommonFactory, OwningTokenFactory};
@@ -351,6 +352,79 @@ if (x < x && a > 0) then duh
         match x {
             EContextAll::MultContext(x) => assert_eq!("(a+4)", x.a.as_ref().unwrap().get_text()),
             _ => panic!("oops"),
+        }
+    }
+
+    // =========================================================================
+    // Error message rule context tests
+    // =========================================================================
+
+    // Error listener that captures formatted error messages into a shared
+    // Vec, so we can inspect them after parsing.
+    struct CollectingErrorListener {
+        messages: std::rc::Rc<std::cell::RefCell<Vec<String>>>,
+    }
+
+    impl<'a, T: antlr4rust::recognizer::Recognizer<'a>>
+        antlr4rust::error_listener::ErrorListener<'a, T> for CollectingErrorListener
+    {
+        fn syntax_error(
+            &self,
+            _recognizer: &T,
+            _offending_symbol: Option<
+                &<T::TF as antlr4rust::token_factory::TokenFactory<'a>>::Inner,
+            >,
+            _line: isize,
+            _column: isize,
+            msg: &str,
+            _error: Option<&ANTLRError>,
+        ) {
+            self.messages.borrow_mut().push(msg.to_string());
+        }
+    }
+
+    // Both `report_no_viable_alternative` and `report_input_mismatch` were
+    // changed to include rule names. With the available test grammars,
+    // `report_input_mismatch` is the easier path to trigger reliably.
+
+    #[test]
+    fn test_input_mismatch_includes_rule_name() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        // Labels grammar: `s : q=e ;` where `e` expects INT, ID, or `(`.
+        // A bare `)` is a valid token (from the `'(' x=e ')'` alternative)
+        // but can't start any `e` alternative, producing a mismatched-input
+        // error in rule `e`.
+        let codepoints = ")".chars().map(|x| x as u32).collect::<Vec<_>>();
+        let lexer = LabelsLexer::new(InputStream::new(&*codepoints));
+        let token_source = CommonTokenStream::new(lexer);
+        let mut parser = LabelsParser::new(token_source);
+
+        let messages = Rc::new(RefCell::new(Vec::new()));
+        parser.remove_error_listeners();
+        parser.add_error_listener(Box::new(CollectingErrorListener {
+            messages: messages.clone(),
+        }));
+
+        let _ = parser.s();
+
+        let msgs = messages.borrow();
+        let mismatch_msgs: Vec<_> = msgs
+            .iter()
+            .filter(|m| m.contains("mismatched input"))
+            .collect();
+        assert!(
+            !mismatch_msgs.is_empty(),
+            "expected a 'mismatched input' error, got: {:?}",
+            *msgs
+        );
+        for msg in &mismatch_msgs {
+            assert!(
+                msg.contains("in rule '"),
+                "mismatched-input message should include rule name, got: {}",
+                msg
+            );
         }
     }
 }


### PR DESCRIPTION
`report_no_viable_alternative` and `report_input_mismatch` in the default error strategy now append `in rule '<name>'` to their messages. Previously these messages provided no context about which grammar rule was being parsed when the error occurred, making it hard to diagnose parse failures in grammars with many alternatives.

The rule name is extracted using the same pattern already used by `report_failed_predicate`:

    recognizer.get_rule_names()
        [recognizer.get_parser_rule_context().get_rule_index()]

This is an improvement over Java's behavior as well — the Java ANTLR4 runtime also omits rule names from these two error paths.

Tested with the Labels grammar by feeding `)` as input, which triggers `report_input_mismatch` in rule `e` (where `e` expects INT, ID, or `(`). The test captures error messages via a custom `ErrorListener` and verifies they contain `in rule '`.