### PR TITLE
feat: Implement hidden token access on `CommonTokenStream`

### DIFF
--- a/runtime/Rust/src/common_token_stream.rs
+++ b/runtime/Rust/src/common_token_stream.rs
@@ -2,7 +2,7 @@
 use std::borrow::Borrow;
 
 use crate::int_stream::{IntStream, IterWrapper, EOF};
-use crate::token::{Token, TOKEN_DEFAULT_CHANNEL, TOKEN_INVALID_TYPE};
+use crate::token::{OwningToken, Token, TOKEN_DEFAULT_CHANNEL, TOKEN_INVALID_TYPE};
 use crate::token_factory::TokenFactory;
 use crate::token_source::TokenSource;
 use crate::token_stream::{TokenStream, UnbufferedTokenStream};
@@ -190,14 +190,90 @@ impl<'input, T: TokenSource<'input>> CommonTokenStream<'input, T> {
 
         i
     }
-    //
-    //    fn previous_token_on_channel(&self, i: isize, channel: isize) -> int { unimplemented!() }
-    //
-    //    fn get_hidden_tokens_to_right(&self, tokenIndex: isize, channel: isize) -> Vec<Token> { unimplemented!() }
-    //
-    //    fn get_hidden_tokens_to_left(&self, tokenIndex: isize, channel: isize) -> Vec<Token> { unimplemented!() }
-    //
-    //    fn filter_for_channel(&self, left: isize, right: isize, channel: isize) -> Vec<Token> { unimplemented!() }
+
+    /// Scans backwards from index `i` looking for a token on the given
+    /// `channel`. Returns the index of the first matching token, or -1 if
+    /// none is found before the start of the stream. EOF tokens are treated
+    /// as matching any channel.
+    fn previous_token_on_channel(&mut self, mut i: isize, channel: i32) -> isize {
+        self.sync(i);
+        if i >= self.size() {
+            return self.size() - 1;
+        }
+
+        while i >= 0 {
+            let token = self.base.tokens[i as usize].borrow();
+            if token.get_token_type() == EOF || token.get_channel() == channel {
+                return i;
+            }
+            i -= 1;
+        }
+
+        -1
+    }
+
+    /// Collects tokens in the index range `[from, to]` that are on the
+    /// given `channel`. If `channel` is -1, collects all tokens that are
+    /// *not* on `TOKEN_DEFAULT_CHANNEL`. Returns `None` if no tokens match.
+    fn filter_for_channel(&self, from: isize, to: isize, channel: i32) -> Option<Vec<OwningToken>> {
+        let mut hidden: Vec<OwningToken> = Vec::new();
+        for i in from..=to {
+            if i < 0 || i >= self.base.tokens.len() as isize {
+                continue;
+            }
+            let t = self.base.tokens[i as usize].borrow();
+            if channel == -1 {
+                if t.get_channel() != TOKEN_DEFAULT_CHANNEL {
+                    hidden.push(t.to_owned());
+                }
+            } else if t.get_channel() == channel {
+                hidden.push(t.to_owned());
+            }
+        }
+
+        if hidden.is_empty() {
+            None
+        } else {
+            Some(hidden)
+        }
+    }
+
+    /// Returns hidden tokens to the left of `token_index` on the given
+    /// `channel`. Scans backwards to the previous on-channel token and
+    /// collects everything in between. Pass -1 as `channel` to get all
+    /// non-default-channel tokens.
+    pub fn get_hidden_tokens_to_left(
+        &mut self,
+        token_index: isize,
+        channel: i32,
+    ) -> Option<Vec<OwningToken>> {
+        let prev_on_channel =
+            self.previous_token_on_channel(token_index - 1, TOKEN_DEFAULT_CHANNEL);
+        let from = if prev_on_channel == token_index - 1 || prev_on_channel < 0 {
+            return None;
+        } else {
+            prev_on_channel + 1
+        };
+        self.filter_for_channel(from, token_index - 1, channel)
+    }
+
+    /// Returns hidden tokens to the right of `token_index` on the given
+    /// `channel`. Scans forward to the next on-channel token and collects
+    /// everything in between. Pass -1 as `channel` to get all
+    /// non-default-channel tokens.
+    pub fn get_hidden_tokens_to_right(
+        &mut self,
+        token_index: isize,
+        channel: i32,
+    ) -> Option<Vec<OwningToken>> {
+        let next_on_channel = self.next_token_on_channel(token_index + 1, TOKEN_DEFAULT_CHANNEL, 1);
+        let to = next_on_channel - 1;
+        if to <= token_index {
+            return None;
+        }
+        self.filter_for_channel(token_index + 1, to, channel)
+    }
+
     //
     //    fn get_source_name(&self) -> String { unimplemented!() }
     //

--- a/runtime/Rust/tests/general_tests.rs
+++ b/runtime/Rust/tests/general_tests.rs
@@ -353,4 +353,82 @@ if (x < x && a > 0) then duh
             _ => panic!("oops"),
         }
     }
+
+    // =========================================================================
+    // Hidden token access tests
+    // =========================================================================
+
+    // CSV grammar uses `WS : [ ]+ -> channel(HIDDEN)`, so spaces become
+    // hidden-channel tokens that remain in the buffer. These tests verify
+    // that `get_hidden_tokens_to_left` and `get_hidden_tokens_to_right`
+    // correctly locate them.
+
+    #[test]
+    fn test_hidden_tokens_to_left() {
+        use antlr4rust::token::TOKEN_HIDDEN_CHANNEL;
+        let tf = ArenaCommonFactory::default();
+        // "V1 ,V2\nd1,d2\n" — the space before the comma is a hidden WS token
+        let lexer = CSVLexer::new_with_token_factory(InputStream::new("V1 ,V2\nd1,d2\n"), &tf);
+        let mut ts = CommonTokenStream::new(lexer);
+
+        // Fill the entire token buffer so all tokens are available.
+        while ts.la(1) != TOKEN_EOF {
+            ts.consume();
+        }
+
+        // Buffer layout:
+        //   0: "V1"  (TEXT, DEFAULT,  start=0, stop=1)
+        //   1: " "   (WS,  HIDDEN,   start=2, stop=2)
+        //   2: ","   (lit, DEFAULT,   start=3, stop=3)
+        //   3: "V2"  (TEXT, DEFAULT,  start=4, stop=5)
+        //   ...
+
+        // Hidden tokens to the left of the comma (index 2) should be the WS.
+        let hidden = ts.get_hidden_tokens_to_left(2, TOKEN_HIDDEN_CHANNEL);
+        let hidden = hidden.expect("expected hidden tokens to the left of comma");
+        assert_eq!(hidden.len(), 1);
+        assert_eq!(hidden[0].get_text(), " ");
+
+        // No hidden tokens to the left of the first token (index 0).
+        assert!(
+            ts.get_hidden_tokens_to_left(0, TOKEN_HIDDEN_CHANNEL)
+                .is_none(),
+            "no hidden tokens before the first token"
+        );
+
+        // No hidden tokens to the left of "V2" (index 3); comma at index 2
+        // is on DEFAULT channel, so there's nothing in between.
+        assert!(
+            ts.get_hidden_tokens_to_left(3, TOKEN_HIDDEN_CHANNEL)
+                .is_none(),
+            "no hidden tokens between comma and V2"
+        );
+    }
+
+    #[test]
+    fn test_hidden_tokens_to_right() {
+        use antlr4rust::token::TOKEN_HIDDEN_CHANNEL;
+
+        let tf = ArenaCommonFactory::default();
+        let lexer = CSVLexer::new_with_token_factory(InputStream::new("V1 ,V2\nd1,d2\n"), &tf);
+        let mut ts = CommonTokenStream::new(lexer);
+
+        while ts.la(1) != TOKEN_EOF {
+            ts.consume();
+        }
+
+        // Hidden tokens to the right of "V1" (index 0) should be the WS.
+        let hidden = ts.get_hidden_tokens_to_right(0, TOKEN_HIDDEN_CHANNEL);
+        let hidden = hidden.expect("expected hidden tokens to the right of V1");
+        assert_eq!(hidden.len(), 1);
+        assert_eq!(hidden[0].get_text(), " ");
+
+        // No hidden tokens to the right of comma (index 2); "V2" at index 3
+        // is on DEFAULT channel with nothing in between.
+        assert!(
+            ts.get_hidden_tokens_to_right(2, TOKEN_HIDDEN_CHANNEL)
+                .is_none(),
+            "no hidden tokens between comma and V2"
+        );
+    }
 }


### PR DESCRIPTION
The Java ANTLR4 runtime provides `getHiddenTokensToLeft` and `getHiddenTokensToRight` on `CommonTokenStream` for retrieving off-channel tokens adjacent to a given token index. The Rust runtime had commented-out stubs for these but no implementation.

This implements four methods:

- `previous_token_on_channel` (private) — backwards counterpart to the existing `next_token_on_channel`
- `filter_for_channel` (private) — collects tokens in a range matching a given channel
- `get_hidden_tokens_to_left` (public) — returns hidden tokens between the previous on-channel token and the given index
- `get_hidden_tokens_to_right` (public) — returns hidden tokens between the given index and the next on-channel token

The two helper methods are private to match `next_token_on_channel`, which is also private. The public API surface is just the two `get_hidden_tokens_to_*` methods, which return `Option<Vec<OwningToken>>` — owned copies since the borrow checker makes returning references into the token buffer impractical here.

Tested with the CSV grammar, which uses `WS -> channel(HIDDEN)`, verifying that hidden whitespace tokens are correctly located in both directions and that boundary conditions (first token, adjacent on-channel tokens) return `None`.