### PR TITLE
fix: `ParserATNSimulator` to be stored in `Rc`

### DIFF
--- a/runtime/Rust/src/parser.rs
+++ b/runtime/Rust/src/parser.rs
@@ -113,7 +113,7 @@ pub struct BaseParser<
     Ctx: ParserNodeType<'input, TF = I::TF>, // Ctx::Type is trait object type for tree node of the parser
     T: ParseTreeListener<'input, Ctx> + ?Sized = dyn ParseTreeListener<'input, Ctx>,
 > {
-    interp: Arc<ParserATNSimulator>,
+    interp: Rc<ParserATNSimulator>,
     /// Rule context parser is currently processing
     pub ctx: Option<Rc<Ctx::Type>>,
 
@@ -400,7 +400,7 @@ where
     //     TerminalNode<'input, Ctx>: CoerceTo<Ctx::Type>,
     //     ErrorNode<'input, Ctx>: CoerceTo<Ctx::Type>,
 {
-    pub fn new_base_parser(input: I, interpreter: Arc<ParserATNSimulator>, ext: Ext) -> Self {
+    pub fn new_base_parser(input: I, interpreter: Rc<ParserATNSimulator>, ext: Ext) -> Self {
         Self {
             interp: interpreter,
             ctx: None,

--- a/runtime/Rust/tests/gen/csvparser.rs
+++ b/runtime/Rust/tests/gen/csvparser.rs
@@ -91,7 +91,7 @@ where
     I: TokenStream<'input, TF = LocalTokenFactory<'input> > + TidAble<'input>,
 {
 	base:BaseParserType<'input,I>,
-	interpreter:Arc<ParserATNSimulator>,
+	interpreter:Rc<ParserATNSimulator>,
 	_shared_context_cache: Box<PredictionContextCache>,
     pub err_handler: Box<dyn ErrorStrategy<'input,BaseParserType<'input,I> > >,
 }
@@ -105,7 +105,7 @@ where
     }
 
     pub fn with_strategy(input: I, strategy: Box<dyn ErrorStrategy<'input,BaseParserType<'input,I> > >) -> Self {
-		let interpreter = Arc::new(ParserATNSimulator::new(
+		let interpreter = Rc::new(ParserATNSimulator::new(
 			_ATN.clone(),
 			_decision_to_DFA.clone(),
 			_shared_context_cache.clone(),
@@ -113,7 +113,7 @@ where
 		Self {
 			base: BaseParser::new_base_parser(
 				input,
-				Arc::clone(&interpreter),
+				Rc::clone(&interpreter),
 				CSVParserExt{
 					_pd: Default::default(),
 				}

--- a/runtime/Rust/tests/gen/labelsparser.rs
+++ b/runtime/Rust/tests/gen/labelsparser.rs
@@ -90,7 +90,7 @@ where
     I: TokenStream<'input, TF = LocalTokenFactory<'input> > + TidAble<'input>,
 {
 	base:BaseParserType<'input,I>,
-	interpreter:Arc<ParserATNSimulator>,
+	interpreter:Rc<ParserATNSimulator>,
 	_shared_context_cache: Box<PredictionContextCache>,
     pub err_handler: Box<dyn ErrorStrategy<'input,BaseParserType<'input,I> > >,
 }
@@ -104,7 +104,7 @@ where
     }
 
     pub fn with_strategy(input: I, strategy: Box<dyn ErrorStrategy<'input,BaseParserType<'input,I> > >) -> Self {
-		let interpreter = Arc::new(ParserATNSimulator::new(
+		let interpreter = Rc::new(ParserATNSimulator::new(
 			_ATN.clone(),
 			_decision_to_DFA.clone(),
 			_shared_context_cache.clone(),
@@ -112,7 +112,7 @@ where
 		Self {
 			base: BaseParser::new_base_parser(
 				input,
-				Arc::clone(&interpreter),
+				Rc::clone(&interpreter),
 				LabelsParserExt{
 					_pd: Default::default(),
 				}

--- a/runtime/Rust/tests/gen/referencetoatnparser.rs
+++ b/runtime/Rust/tests/gen/referencetoatnparser.rs
@@ -82,7 +82,7 @@ where
     I: TokenStream<'input, TF = LocalTokenFactory<'input> > + TidAble<'input>,
 {
 	base:BaseParserType<'input,I>,
-	interpreter:Arc<ParserATNSimulator>,
+	interpreter:Rc<ParserATNSimulator>,
 	_shared_context_cache: Box<PredictionContextCache>,
     pub err_handler: Box<dyn ErrorStrategy<'input,BaseParserType<'input,I> > >,
 }
@@ -96,7 +96,7 @@ where
     }
 
     pub fn with_strategy(input: I, strategy: Box<dyn ErrorStrategy<'input,BaseParserType<'input,I> > >) -> Self {
-		let interpreter = Arc::new(ParserATNSimulator::new(
+		let interpreter = Rc::new(ParserATNSimulator::new(
 			_ATN.clone(),
 			_decision_to_DFA.clone(),
 			_shared_context_cache.clone(),
@@ -104,7 +104,7 @@ where
 		Self {
 			base: BaseParser::new_base_parser(
 				input,
-				Arc::clone(&interpreter),
+				Rc::clone(&interpreter),
 				ReferenceToATNParserExt{
 					_pd: Default::default(),
 				}

--- a/runtime/Rust/tests/gen/simplelrparser.rs
+++ b/runtime/Rust/tests/gen/simplelrparser.rs
@@ -81,7 +81,7 @@ where
     I: TokenStream<'input, TF = LocalTokenFactory<'input> > + TidAble<'input>,
 {
 	base:BaseParserType<'input,I>,
-	interpreter:Arc<ParserATNSimulator>,
+	interpreter:Rc<ParserATNSimulator>,
 	_shared_context_cache: Box<PredictionContextCache>,
     pub err_handler: Box<dyn ErrorStrategy<'input,BaseParserType<'input,I> > >,
 }
@@ -95,7 +95,7 @@ where
     }
 
     pub fn with_strategy(input: I, strategy: Box<dyn ErrorStrategy<'input,BaseParserType<'input,I> > >) -> Self {
-		let interpreter = Arc::new(ParserATNSimulator::new(
+		let interpreter = Rc::new(ParserATNSimulator::new(
 			_ATN.clone(),
 			_decision_to_DFA.clone(),
 			_shared_context_cache.clone(),
@@ -103,7 +103,7 @@ where
 		Self {
 			base: BaseParser::new_base_parser(
 				input,
-				Arc::clone(&interpreter),
+				Rc::clone(&interpreter),
 				SimpleLRParserExt{
 					_pd: Default::default(),
 				}

--- a/runtime/Rust/tests/gen/visitorbasicparser.rs
+++ b/runtime/Rust/tests/gen/visitorbasicparser.rs
@@ -82,7 +82,7 @@ where
     I: TokenStream<'input, TF = LocalTokenFactory<'input> > + TidAble<'input>,
 {
 	base:BaseParserType<'input,I>,
-	interpreter:Arc<ParserATNSimulator>,
+	interpreter:Rc<ParserATNSimulator>,
 	_shared_context_cache: Box<PredictionContextCache>,
     pub err_handler: Box<dyn ErrorStrategy<'input,BaseParserType<'input,I> > >,
 }
@@ -96,7 +96,7 @@ where
     }
 
     pub fn with_strategy(input: I, strategy: Box<dyn ErrorStrategy<'input,BaseParserType<'input,I> > >) -> Self {
-		let interpreter = Arc::new(ParserATNSimulator::new(
+		let interpreter = Rc::new(ParserATNSimulator::new(
 			_ATN.clone(),
 			_decision_to_DFA.clone(),
 			_shared_context_cache.clone(),
@@ -104,7 +104,7 @@ where
 		Self {
 			base: BaseParser::new_base_parser(
 				input,
-				Arc::clone(&interpreter),
+				Rc::clone(&interpreter),
 				VisitorBasicParserExt{
 					_pd: Default::default(),
 				}

--- a/runtime/Rust/tests/gen/visitorcalcparser.rs
+++ b/runtime/Rust/tests/gen/visitorcalcparser.rs
@@ -89,7 +89,7 @@ where
     I: TokenStream<'input, TF = LocalTokenFactory<'input> > + TidAble<'input>,
 {
 	base:BaseParserType<'input,I>,
-	interpreter:Arc<ParserATNSimulator>,
+	interpreter:Rc<ParserATNSimulator>,
 	_shared_context_cache: Box<PredictionContextCache>,
     pub err_handler: Box<dyn ErrorStrategy<'input,BaseParserType<'input,I> > >,
 }
@@ -103,7 +103,7 @@ where
     }
 
     pub fn with_strategy(input: I, strategy: Box<dyn ErrorStrategy<'input,BaseParserType<'input,I> > >) -> Self {
-		let interpreter = Arc::new(ParserATNSimulator::new(
+		let interpreter = Rc::new(ParserATNSimulator::new(
 			_ATN.clone(),
 			_decision_to_DFA.clone(),
 			_shared_context_cache.clone(),
@@ -111,7 +111,7 @@ where
 		Self {
 			base: BaseParser::new_base_parser(
 				input,
-				Arc::clone(&interpreter),
+				Rc::clone(&interpreter),
 				VisitorCalcParserExt{
 					_pd: Default::default(),
 				}

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Rust/Rust.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Rust/Rust.stg
@@ -299,7 +299,7 @@ where
     I: TokenStream\<'input, TF = <TokenFactory()> > + TidAble\<'input>,
 {
 	base:BaseParserType\<'input,I>,
-	interpreter:Arc\<ParserATNSimulator>,
+	interpreter:Rc\<ParserATNSimulator>,
 	_shared_context_cache: Box\<PredictionContextCache>,
     pub err_handler: Box\<dyn ErrorStrategy\<'input,BaseParserType\<'input,I> > >,
 }
@@ -313,7 +313,7 @@ where
     }
 
     pub fn with_strategy(input: I, strategy: Box\<dyn ErrorStrategy\<'input,BaseParserType\<'input,I> > >) -> Self {
-		let interpreter = Arc::new(ParserATNSimulator::new(
+		let interpreter = Rc::new(ParserATNSimulator::new(
 			_ATN.clone(),
 			_decision_to_DFA.clone(),
 			_shared_context_cache.clone(),
@@ -321,7 +321,7 @@ where
 		Self {
 			base: BaseParser::new_base_parser(
 				input,
-				Arc::clone(&interpreter),
+				Rc::clone(&interpreter),
 				<parser.name>Ext{
 					_pd: Default::default(),
 					<namedActions.init>


### PR DESCRIPTION
Fixes #41 

~To be clear, I don't think this is "thread safe" as in "can be used by multiple threads concurrently", but rather this can now be safely shared across threads (as it was already stored in an `Arc`). Visibility wasn't guaranteed, now it should be.~

Now not shared across threads boundaries anymore.

Eventually, this probably should all be revisited and agreed upon how this is (or not) to be concurrent and have an API that clearly reflects that. 